### PR TITLE
設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*


### PR DESCRIPTION
# What
public/uploadsをコミットしないよう.gitignoreに記述。

#Why
投稿された画像自体はソースコードには関係のないから。